### PR TITLE
Add support for "Unsplash" (https://unsplash.com/)

### DIFF
--- a/includes/social-networks.php
+++ b/includes/social-networks.php
@@ -166,4 +166,11 @@ $fields = [
 		'default' => "https://trello.com/b/{$board}",
 		'select'  => $board,
 	],
+	'unsplash'     => [
+                'icon'       => 'camera',
+		'label'      => __( 'Unsplash', 'contact-widgets' ),
+		'default'    => "https://unsplash.com/@{$username}",
+		'select'     => $username,
+		'deprecated' => false,
+	],
 ];


### PR DESCRIPTION
I added the section for 'unsplash' at the end: I forgot any preference in positioning to this regard. Had to override the icon to 'camera' as that is what they have, and there isn't an unsplash-specific one in this plugin.